### PR TITLE
fixed bad additions causing odd create errors

### DIFF
--- a/server/database/createTable.sql
+++ b/server/database/createTable.sql
@@ -207,11 +207,10 @@ WHERE column_name = 'task_id' LOOP EXECUTE format(
 END LOOP;
 END $$ LANGUAGE plpgsql;
 SELECT task_id_tables();
-INSERT INTO task (completed, title, id)
+INSERT INTO task (completed, title)
 VALUES (
         true,
         'give ABN an A for their Alpha Release!',
-        1
     );
-INSERT INTO task (completed, title, id)
-VALUES (false, 'make dinner', 2);
+INSERT INTO task (completed, title)
+VALUES (false, 'make dinner');


### PR DESCRIPTION
test entities that were added to the first creation of tasks had ID forced into the insert statements, this was causing bad creation. I have fixed this in the 4 lines associated